### PR TITLE
Fixing Error on Clang 9.0

### DIFF
--- a/src/gmhmm/gaussian.cpp
+++ b/src/gmhmm/gaussian.cpp
@@ -102,7 +102,7 @@ void Gaussian::train(vector<vector<pair<int, double> > > &train_set)
         
     for (int i=0;i<obs;i++) sigma[i] = sqrt(sigma[i] / (cnt[i] - 1));
         
-    delete cnt;
+    delete[] cnt;
 }
 
 // Get the probability of producing output x, assuming the sub-output is obs_id


### PR DESCRIPTION
```
grok-machine:muxstep dendisuhubdy$ make
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C src/classifier/ ../../build/classifier_multiplex_gmhmm.o
mkdir -p ../../build/
clang++ -I../../include -std=c++11 -O3 -fPIC -Wall -Wextra -Werror -Weffc++ -Wstrict-aliasing --pedantic -c -g classifier_multiplex_gmhmm.cpp -o ../../build/classifier_multiplex_gmhmm.o
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C src/classifier/ ../../build/classifier_k_ary.o
mkdir -p ../../build/
clang++ -I../../include -std=c++11 -O3 -fPIC -Wall -Wextra -Werror -Weffc++ -Wstrict-aliasing --pedantic -c -g classifier_k_ary.cpp -o ../../build/classifier_k_ary.o
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C src/gmhmm/ ../../build/gmhmm.o
mkdir -p ../../build/
clang++ -I../../include -std=c++11 -O3 -fPIC -Wall -Wextra -Werror -Weffc++ -Wstrict-aliasing --pedantic -c -g gmhmm.cpp -o ../../build/gmhmm.o
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C src/multiplex_gmhmm ../../build/multiplex_gmhmm.o
mkdir -p ../../build/
clang++ -I../../include -std=c++11 -O3 -fPIC -Wall -Wextra -Werror -Weffc++ -Wstrict-aliasing --pedantic -c -g multiplex_gmhmm.cpp -o ../../build/multiplex_gmhmm.o
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C src/nsga2 ../../build/nsga2.o
mkdir -p ../../build/
clang++ -I../../include -std=c++11 -O3 -fPIC -Wall -Wextra -Werror -Weffc++ -Wstrict-aliasing --pedantic -c -g nsga2.cpp -o ../../build/nsga2.o
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C src/gmhmm ../../build/gaussian.o
mkdir -p ../../build/
clang++ -I../../include -std=c++11 -O3 -fPIC -Wall -Wextra -Werror -Weffc++ -Wstrict-aliasing --pedantic -c -g gaussian.cpp -o ../../build/gaussian.o
gaussian.cpp:105:5: error: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'?
      [-Werror,-Wmismatched-new-delete]
    delete cnt;
    ^
          []
gaussian.cpp:74:16: note: allocated with 'new[]' here
    int *cnt = new int[obs];
               ^
1 error generated.
make[1]: *** [../../build/gaussian.o] Error 1
make: *** [build/gaussian.o] Error 2
```